### PR TITLE
Phragmenelection vote amount read as balance

### DIFF
--- a/app/src/substrate/substrate_dispatch_V18.c
+++ b/app/src/substrate/substrate_dispatch_V18.c
@@ -729,7 +729,7 @@ __Z_INLINE parser_error_t _readMethod_phragmenelection_vote_V18(
     parser_context_t* c, pd_phragmenelection_vote_V18_t* m)
 {
     CHECK_ERROR(_readVecAccountId(c, &m->votes))
-    CHECK_ERROR(_readCompactu128(c, &m->amount))
+    CHECK_ERROR(_readCompactBalance(c, &m->amount))
     return parser_ok;
 }
 
@@ -8266,7 +8266,7 @@ parser_error_t _getMethod_ItemValue_V18(
                 outValue, outValueLen,
                 pageIdx, pageCount);
         case 1: /* phragmenelection_vote_V18 - amount */;
-            return _toStringCompactu128(
+            return _toStringCompactBalance(
                 &m->basic.phragmenelection_vote_V18.amount,
                 outValue, outValueLen,
                 pageIdx, pageCount);

--- a/app/src/substrate/substrate_dispatch_V19.c
+++ b/app/src/substrate/substrate_dispatch_V19.c
@@ -736,7 +736,7 @@ __Z_INLINE parser_error_t _readMethod_phragmenelection_vote_V19(
     parser_context_t* c, pd_phragmenelection_vote_V19_t* m)
 {
     CHECK_ERROR(_readVecAccountId(c, &m->votes))
-    CHECK_ERROR(_readCompactu128(c, &m->amount))
+    CHECK_ERROR(_readCompactBalance(c, &m->amount))
     return parser_ok;
 }
 
@@ -8276,7 +8276,7 @@ parser_error_t _getMethod_ItemValue_V19(
                 outValue, outValueLen,
                 pageIdx, pageCount);
         case 1: /* phragmenelection_vote_V19 - amount */;
-            return _toStringCompactu128(
+            return _toStringCompactBalance(
                 &m->basic.phragmenelection_vote_V19.amount,
                 outValue, outValueLen,
                 pageIdx, pageCount);

--- a/app/src/substrate/substrate_methods_V18.h
+++ b/app/src/substrate/substrate_methods_V18.h
@@ -431,7 +431,7 @@ typedef struct {
 #define PD_CALL_PHRAGMENELECTION_VOTE_V18 0
 typedef struct {
     pd_VecAccountId_t votes;
-    pd_Compactu128_t amount;
+    pd_CompactBalance_t amount;
 } pd_phragmenelection_vote_V18_t;
 
 #define PD_CALL_PHRAGMENELECTION_REMOVE_VOTER_V18 1

--- a/app/src/substrate/substrate_methods_V19.h
+++ b/app/src/substrate/substrate_methods_V19.h
@@ -436,7 +436,7 @@ typedef struct {
 #define PD_CALL_PHRAGMENELECTION_VOTE_V19 0
 typedef struct {
     pd_VecAccountId_t votes;
-    pd_Compactu128_t amount;
+    pd_CompactBalance_t amount;
 } pd_phragmenelection_vote_V19_t;
 
 #define PD_CALL_PHRAGMENELECTION_REMOVE_VOTER_V19 1


### PR DESCRIPTION
Hi,

The amount for `Phragmenelection vote` is `Compact<u128> (BalanceOf)` on Polkadot/substrate portal, and is being read in ledger app as `Compactu128`  however, other amount entities, despite being `Compact<u128>` are being read as `Compact Balance`, which is a much better user experience, as it does not require user to count chain decimals and subtract them out form what is displayed on screen.

`Phragmenelection vote` was being shown in ledger UI with additional chain decimals.

It may be a better user experience to read this amount as balance.

<img width="702" alt="PR_Working" src="https://user-images.githubusercontent.com/6935470/215795118-3c28f86b-57db-4f90-9613-0fc45c034f7d.png">


Thanks

<!-- ClickUpRef: 86779tmgr -->
:link: [zboto Link](https://app.clickup.com/t/86779tmgr)